### PR TITLE
Fix Hap Dependencies

### DIFF
--- a/custom-characteristics.js
+++ b/custom-characteristics.js
@@ -1,4 +1,4 @@
-const { Characteristic } = require('hap-nodejs');
+const { Characteristic } = require('./index');
 
 const DeviceTypeUUID = '2af07946-01da-11e8-ba89-0ed5f89f718b';
 const DeviceType = function () {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const CastDefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver;
 const pkginfo = require('./package');
 const CustomCharacteristics = require('./custom-characteristics');
 
-let hap, Service, Characteristic, PlatformAccessory, UUIDGen;
+let Hap, Service, Characteristic, PlatformAccessory, UUIDGen;
 
 const mdnsSequence = [
   mdns.rst.DNSServiceResolve(),

--- a/index.js
+++ b/index.js
@@ -1003,6 +1003,7 @@ module.exports = function (homebridge) {
   Characteristic = homebridge.hap.Characteristic; 
   Service = homebridge.hap.Service; 
   UUIDGen = homebridge.hap.uuid;
+  hap = homebridhe.hap;
 
   homebridge.registerPlatform('homebridge-chromecast-television', 'ChromecastTelevision', ControlChromecastPlatform, true);
   //homebridge.publishExternalAccessories('homebridge-chromecast-television', this.accessories);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const CastDefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver;
 const pkginfo = require('./package');
 const CustomCharacteristics = require('./custom-characteristics');
 
-let Service, Characteristic, PlatformAccessory, hap, UUIDGen;
+let hap, Service, Characteristic, PlatformAccessory, UUIDGen;
 
 const mdnsSequence = [
   mdns.rst.DNSServiceResolve(),

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const CastDefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver;
 const pkginfo = require('./package');
 const CustomCharacteristics = require('./custom-characteristics');
 
-let Hap, Service, Characteristic, PlatformAccessory, UUIDGen;
+let hap, Service, Characteristic, PlatformAccessory, UUIDGen;
 
 const mdnsSequence = [
   mdns.rst.DNSServiceResolve(),

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const CastDefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver;
 const pkginfo = require('./package');
 const CustomCharacteristics = require('./custom-characteristics');
 
-let Service, Characteristic, PlatformAccessory, UUIDGen;
+let Service, Characteristic, PlatformAccessory, hap, UUIDGen;
 
 const mdnsSequence = [
   mdns.rst.DNSServiceResolve(),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "castv2-client": "^1.2.0",
-    "hap-nodejs": "^0.4.28",
     "mdns": "^2.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
In its current state the plugin installs an extra copy of hapnodejs and homebridge generates a warning. This PR fixes that by leveraging hap from Homebridge itself.

Here is a summary of the changes:
1. I updated Package.json to remove the dependency.
2. I updated index.js to allow & define hap.
3. I updated custom-characteristics.js to reference hap.characteristic definitions in index.js